### PR TITLE
Fix to use the refresh_token in ticket if it's not present in the response when refreshing the access token

### DIFF
--- a/lib/strategy.js
+++ b/lib/strategy.js
@@ -94,6 +94,8 @@ OAuth2RefreshTokenStrategy.prototype.authenticate = function(req, options) {
         return self.fail(err);
       }
 
+      refreshToken =  refreshToken || ticket.refresh_token;
+
       if (accessToken && refreshToken) {
         var expires = params.expires_in ?
           moment().add(params.expires_in, 'seconds') :


### PR DESCRIPTION
The actual code is expecting a new refresh_token to come as part of the response after refreshing the access token. If there is an existing refresh token in the ticket, the flow should continue instead of failing. 
